### PR TITLE
Refactor profile README to remove redundant information

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 
 name: Eduardo Macías
 handle: "@herwingx"
-location: Chiapas, México
-timezone: UTC-06:00
 
 role: Full Stack Developer Jr
 focus:
@@ -134,12 +132,6 @@ $ tree ~/projects --dirsfirst
 
 </div>
 
-## `$ git log --graph --all`
-
-<div align="center">
-<img src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=herwingx&theme=github_dark" width="100%"/>
-</div>
-
 ---
 
 ## `$ ./snake_game.sh --simulate`
@@ -154,7 +146,6 @@ $ tree ~/projects --dirsfirst
 
 ```json
 {
-  "user": "Eduardo Macías",
   "email": "herwingx@gmail.com",
   "social": {
     "linkedin": "https://linkedin.com/in/herwingx",


### PR DESCRIPTION
This commit refactors the GitHub profile README by identifying and removing redundant information. This results in a cleaner and more streamlined profile representation.

The changes include:
1.  **`profile.yml` simplification:** Dropped `location` and `timezone` to keep it focused on the developer role and objectives, since location and timezone info are generally available on the GitHub profile page natively or in the `neofetch` block.
2.  **Stats card cleanup:** Removed the `profile-details` card under the `## $ git log --graph --all` heading to reduce clutter, as the `stats` card under `## $ git log --oneline` already provides overlapping information.
3.  **`contact.json` cleanup:** Dropped the `user` field, avoiding repetition of the name (`Eduardo Macías`) which is clearly visible at the top of the README.

---
*PR created automatically by Jules for task [5199252636601328459](https://jules.google.com/task/5199252636601328459) started by @herwingx*